### PR TITLE
feat!: parse JSON with System.Text.Json

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x' # Change this to the .NET version you are using
+        dotnet-version: '8.0.x' # Change this to the .NET version you are using
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,7 @@ name: Publish .NET Package
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
@@ -23,8 +21,10 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
     - name: Publish
       run: dotnet pack --configuration Release --no-build --output ./artifacts
+      if: github.ref == 'refs/heads/master'
     - name: Push to GitHub Packages
       run: dotnet nuget push ./artifacts/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/top-gg/index.json --skip-duplicate
+      if: github.ref == 'refs/heads/master'
 
 env:
   DOTNET_NOLOGO: true

--- a/ProxyCheck.sln
+++ b/ProxyCheck.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.26403.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProxyCheckUtil", "ProxyCheck\ProxyCheckUtil.csproj", "{234ED760-6E95-4C53-B4EE-D4612A9E5BAD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProxyCheckUtil.Tests", "ProxyCheckUtil.Tests\ProxyCheckUtil.Tests.csproj", "{D768DB67-D857-4CA3-A8BA-88CA0F5E2306}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{234ED760-6E95-4C53-B4EE-D4612A9E5BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{234ED760-6E95-4C53-B4EE-D4612A9E5BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{234ED760-6E95-4C53-B4EE-D4612A9E5BAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D768DB67-D857-4CA3-A8BA-88CA0F5E2306}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D768DB67-D857-4CA3-A8BA-88CA0F5E2306}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D768DB67-D857-4CA3-A8BA-88CA0F5E2306}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D768DB67-D857-4CA3-A8BA-88CA0F5E2306}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProxyCheck/Http/DefaultHttpClientFactory.cs
+++ b/ProxyCheck/Http/DefaultHttpClientFactory.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Net.Http;
+using JetBrains.Annotations;
+
+namespace ProxyCheckUtil
+{
+    /// <summary>
+    /// Simple implementation of <see cref="IHttpClientFactory"/> that creates a single <see cref="System.Net.Http.HttpClient"/> instance.
+    /// Not recommended for production use, since it doesn't respect DNS changes.
+    ///
+    /// Creating a new <see cref="System.Net.Http.HttpClient"/> instance for each request will lead to connection pool exhaustion.
+    /// Use the pooling from the 'Microsoft.Extensions.Http' package instead.
+    /// </summary>
+    internal class DefaultHttpClientFactory : IHttpClientFactory
+    {
+        private static readonly HttpClient HttpClient = new NonDisposableHttpClient();
+
+        public HttpClient CreateClient(string name)
+        {
+            return HttpClient;
+        }
+
+        private class NonDisposableHttpClient : HttpClient
+        {
+            protected override void Dispose(bool disposing)
+            {
+                // Do nothing, since we want to keep the HttpClient instance alive.
+            }
+        }
+    }
+}

--- a/ProxyCheck/IProxyCheckCacheProvider.cs
+++ b/ProxyCheck/IProxyCheckCacheProvider.cs
@@ -5,7 +5,7 @@ namespace ProxyCheckUtil
 {
     public interface IProxyCheckCacheProvider
     {
-        ProxyCheckResult.IpResult GetCacheRecord(IPAddress ip, ProxyCheckRequestOptions options);
+        ProxyCheckResult.IpResult? GetCacheRecord(IPAddress ip, ProxyCheckRequestOptions options);
 
         IDictionary<IPAddress, ProxyCheckResult.IpResult> GetCacheRecords(IPAddress[] ipAddress, ProxyCheckRequestOptions options);
 

--- a/ProxyCheck/Json/IpResultDictionary.cs
+++ b/ProxyCheck/Json/IpResultDictionary.cs
@@ -1,0 +1,145 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+
+namespace ProxyCheckUtil
+{
+    /// <summary>
+    /// Dictionary that deserializes IP addresses keys as <see cref="IPAddress"/> and values as <see cref="ProxyCheckResult.IpResult"/>.
+    /// </summary>
+    internal class IpResultDictionary : IDictionary<string, JsonElement>
+    {
+        private readonly Dictionary<string, JsonElement> _extensionData = new();
+        private readonly Dictionary<IPAddress, ProxyCheckResult.IpResult> _results;
+
+        public IpResultDictionary(Dictionary<IPAddress, ProxyCheckResult.IpResult> results)
+        {
+            _results = results;
+        }
+
+        public IEnumerator<KeyValuePair<string, JsonElement>> GetEnumerator()
+        {
+            foreach (var kvp in _results)
+            {
+                yield return new KeyValuePair<string, JsonElement>(kvp.Key.ToString(), JsonSerializer.SerializeToDocument(kvp.Value, ProxyJsonContext.Default.IpResult).RootElement);
+            }
+
+            foreach (var kvp in _extensionData)
+            {
+                yield return kvp;
+            }
+        }
+
+        public void Add(KeyValuePair<string, JsonElement> item)
+        {
+            Add(item.Key, item.Value);
+        }
+
+        public void Clear()
+        {
+            _results.Clear();
+            _extensionData.Clear();
+        }
+
+        public bool Contains(KeyValuePair<string, JsonElement> item)
+        {
+            return ContainsKey(item.Key);
+        }
+
+        public void CopyTo(KeyValuePair<string, JsonElement>[] array, int arrayIndex)
+        {
+            foreach (var kvp in _results)
+            {
+                array[arrayIndex++] = new KeyValuePair<string, JsonElement>(kvp.Key.ToString(), JsonSerializer.SerializeToDocument(kvp.Value, ProxyJsonContext.Default.IpResult).RootElement);
+            }
+
+            foreach (var kvp in _extensionData)
+            {
+                array[arrayIndex++] = kvp;
+            }
+        }
+
+        public bool Remove(KeyValuePair<string, JsonElement> item)
+        {
+            return Remove(item.Key);
+        }
+
+        public int Count => _results.Count + _extensionData.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(string key, JsonElement value)
+        {
+            if (IPAddress.TryParse(key, out var ip))
+            {
+                _results.Add(ip, value.Deserialize(ProxyJsonContext.Default.IpResult)!);
+            }
+            else
+            {
+                _extensionData.Add(key, value);
+            }
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return IPAddress.TryParse(key, out var ip)
+                ? _results.ContainsKey(ip)
+                : _extensionData.ContainsKey(key);
+        }
+
+        public bool Remove(string key)
+        {
+            return IPAddress.TryParse(key, out var ip)
+                ? _results.Remove(ip)
+                : _extensionData.Remove(key);
+        }
+
+        public bool TryGetValue(string key, out JsonElement value)
+        {
+            if (_results.TryGetValue(IPAddress.Parse(key), out var result))
+            {
+                value = JsonSerializer.SerializeToDocument(result, ProxyJsonContext.Default.IpResult).RootElement;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public JsonElement this[string key]
+        {
+            get => IPAddress.TryParse(key, out var ip)
+                ? JsonSerializer.SerializeToDocument(_results[ip], ProxyJsonContext.Default.IpResult).RootElement
+                : _extensionData[key];
+
+            set
+            {
+                if (IPAddress.TryParse(key, out var ip))
+                {
+                    _results[ip] = value.Deserialize(ProxyJsonContext.Default.IpResult)!;
+                }
+                else
+                {
+                    _extensionData[key] = value;
+                }
+            }
+        }
+
+        ICollection<string> IDictionary<string, JsonElement>.Keys => _results.Keys
+            .Select(ip => ip.ToString())
+            .Concat(_extensionData.Keys)
+            .ToList();
+
+        ICollection<JsonElement>  IDictionary<string, JsonElement>.Values => _results.Values
+            .Select(result => JsonSerializer.SerializeToDocument(result, ProxyJsonContext.Default.IpResult).RootElement)
+            .Concat(_extensionData.Values)
+            .ToList();
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/ProxyCheck/Json/ProxyJsonContext.cs
+++ b/ProxyCheck/Json/ProxyJsonContext.cs
@@ -1,0 +1,18 @@
+﻿using System.Text.Json.Serialization;
+
+namespace ProxyCheckUtil
+{
+    [JsonSourceGenerationOptions(
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        Converters = new []
+        {
+            typeof(JsonStringEnumConverter<StatusResult>),
+            typeof(JsonStringEnumConverter<RiskLevel>)
+        }
+    )]
+    [JsonSerializable(typeof(ProxyCheckResult))]
+    [JsonSerializable(typeof(ProxyCheckResult.IpResult))]
+    internal partial class ProxyJsonContext : JsonSerializerContext
+    {
+    }
+}

--- a/ProxyCheck/Json/YesNoJsonConverter.cs
+++ b/ProxyCheck/Json/YesNoJsonConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ProxyCheckUtil
+{
+    internal class YesNoJsonConverter : JsonConverter<bool>
+    {
+        public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.GetString() == "yes";
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value ? "yes" : "no");
+        }
+    }
+}

--- a/ProxyCheck/ProxyCheckRequestOptions.cs
+++ b/ProxyCheck/ProxyCheckRequestOptions.cs
@@ -48,7 +48,7 @@ namespace ProxyCheckUtil
         /// </summary>
         public RiskLevel? RiskLevel { get; set; }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (!(obj is ProxyCheckRequestOptions o))
                 return false;
@@ -72,6 +72,19 @@ namespace ProxyCheckUtil
                 return false;
 
             return IncludeLastSeen == o.IncludeLastSeen;
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = 17;
+            hash = hash * 23 + IncludeVPN.GetHashCode();
+            hash = hash * 23 + UseTLS.GetHashCode();
+            hash = hash * 23 + IncludeASN.GetHashCode();
+            hash = hash * 23 + UseInference.GetHashCode();
+            hash = hash * 23 + IncludePort.GetHashCode();
+            hash = hash * 23 + IncludeLastSeen.GetHashCode();
+            hash = hash * 23 + RiskLevel.GetHashCode();
+            return hash;
         }
     }
 }

--- a/ProxyCheck/ProxyCheckResult.cs
+++ b/ProxyCheck/ProxyCheckResult.cs
@@ -28,6 +28,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 namespace ProxyCheckUtil
@@ -35,24 +37,51 @@ namespace ProxyCheckUtil
     [PublicAPI]
     public class ProxyCheckResult
     {
+        private IpResultDictionary _resultsDictionary;
+
+        public ProxyCheckResult()
+        {
+            Results = new Dictionary<IPAddress, IpResult>();
+            _resultsDictionary = new IpResultDictionary(Results);
+        }
+
         /// <summary>
         /// API status result
         /// </summary>
+        [JsonPropertyName("status")]
         public StatusResult Status { get; set; }
 
         /// <summary>
         /// Answering node
         /// </summary>
-        public string Node { get; set; }
+        [JsonPropertyName("node")]
+        public string? Node { get; set; }
 
         /// <summary>
         /// Dictionary of results for the IP address(es) provided
         /// </summary>
-        public Dictionary<IPAddress, IpResult> Results { get; internal set; } = new Dictionary<IPAddress, IpResult>();
+        [JsonIgnore]
+        public Dictionary<IPAddress, IpResult> Results { get; internal set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, JsonElement> ExtensionData
+        {
+            get => _resultsDictionary;
+            set
+            {
+                _resultsDictionary.Clear();
+
+                foreach (var kv in value)
+                {
+                    _resultsDictionary.Add(kv);
+                }
+            }
+        }
 
         /// <summary>
         /// The amount of time the query took on the server
         /// </summary>
+        [JsonPropertyName("query time")]
         public TimeSpan? QueryTime { get; set; }
 
         [PublicAPI]
@@ -61,17 +90,20 @@ namespace ProxyCheckUtil
             /// <summary>
             /// The ASN the IP address belongs to
             /// </summary>
-            public string ASN { get; set; }
+            [JsonPropertyName("asn")]
+            public string? ASN { get; set; }
 
             /// <summary>
             /// The provider the IP address belongs to
             /// </summary>
-            public string Provider { get; set; }
+            [JsonPropertyName("provider")]
+            public string? Provider { get; set; }
 
             /// <summary>
             /// The country the IP address is in.
             /// </summary>
-            public string Country { get; set; }
+            [JsonPropertyName("country")]
+            public string? Country { get; set; }
 
             /// <summary>
             /// The latitude of the IP address
@@ -79,56 +111,69 @@ namespace ProxyCheckUtil
             /// <remarks>
             /// This is not the exact location of the IP address
             /// </remarks>
+            [JsonPropertyName("latitude")]
             public double? Latitude { get; set; }
+
             /// <summary>
             /// The longitude of the IP address
             /// </summary>
             /// <remarks>
             /// This is not the exact location of the IP address
             /// </remarks>
+            [JsonPropertyName("longitude")]
             public double? Longitude { get; set; }
+
             /// <summary>
             /// The city the of the IP address
             /// </summary>
             /// <remarks>
             /// This may not be the exact city
             /// </remarks>
-            public string City { get; set; }
+            [JsonPropertyName("city")]
+            public string? City { get; set; }
 
             /// <summary>
             /// ISO Country code of the IP address country
             /// </summary>
-            public string ISOCode { get; set; }
+            [JsonPropertyName("isocode")]
+            public string? ISOCode { get; set; }
 
             /// <summary>
             /// True if the IP is detected as proxy
             /// False otherwise
             /// </summary>
+            [JsonPropertyName("proxy")]
+            [JsonConverter(typeof(YesNoJsonConverter))]
             public bool IsProxy { get; set; }
 
             /// <summary>
             /// The type of proxy detected
             /// </summary>
-            public string ProxyType { get; set; }
+            [JsonPropertyName("type")]
+            public string ProxyType { get; set; } = "";
 
             /// <summary>
             /// The port the proxy server is operating on
             /// </summary>
+            [JsonPropertyName("port")]
             public int? Port { get; set; }
 
             /// <summary>
             /// Not null when risk is > 0, the risk score of the IP address
             /// </summary>
+            [JsonPropertyName("risk")]
             public int? RiskScore { get; set; }
             
             /// <summary>
             /// The last time the proxy server was seen in human readable format.
             /// </summary>
-            public string LastSeenHuman { get; set; }
+            [JsonPropertyName("last seen human")]
+            public string? LastSeenHuman { get; set; }
 
             /// <summary>
             /// The last time the proxy server was seen in Unix time stamp
             /// </summary>
+            [JsonPropertyName("last seen unix")]
             public long? LastSeenUnix { get; set; }
 
             /// <summary>
@@ -149,7 +194,7 @@ namespace ProxyCheckUtil
             /// <summary>
             /// If not `null` the description of the error that occured
             /// </summary>
-            public string ErrorMessage { get; set; }
+            public string? ErrorMessage { get; set; }
 
             /// <summary>
             /// True if this item was retrieved from cache

--- a/ProxyCheck/ProxyCheckUtil.csproj
+++ b/ProxyCheck/ProxyCheckUtil.csproj
@@ -5,9 +5,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
     <ApplicationIcon />
     <OutputTypeEx>exe</OutputTypeEx>
+    <LangVersion>9.0</LangVersion>
     <StartupObject />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -15,7 +17,7 @@
     <Company />
     <Description>Checks if an IP address is a public proxy or not using ProxyCheck.IO</Description>
     <Copyright>Public Domain</Copyright>
-    <PackageLicenseUrl>https://github.com/hollow87/ProxyCheck/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicense>https://github.com/hollow87/ProxyCheck/blob/master/LICENSE</PackageLicense>
     <PackageProjectUrl>https://github.com/hollow87/ProxyCheck</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hollow87/ProxyCheck</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -31,14 +33,15 @@
     <AssemblyVersion>2.0.1.0</AssemblyVersion>
     <FileVersion>2.0.1.0</FileVersion>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Users\Mikey\Source\Repos\ProxyCheck\ProxyCheck\ProxyCheckUtil.xml</DocumentationFile>
+  
+  <PropertyGroup Condition="$(TargetFramework) == 'net8.0'">
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
 </Project>

--- a/ProxyCheck/ProxyCheckUtil.csproj.DotSettings
+++ b/ProxyCheck/ProxyCheckUtil.csproj.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=http/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=json/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/ProxyCheck/SimpleInMemoryCache.cs
+++ b/ProxyCheck/SimpleInMemoryCache.cs
@@ -12,10 +12,10 @@ namespace ProxyCheckUtil
 
         private class CacheItem
         {
-            public IPAddress IPAddress { get; set; }
-            public ProxyCheckRequestOptions Options { get; set; }
+            public IPAddress IPAddress { get; set; } = null!;
+            public ProxyCheckRequestOptions Options { get; set; } = null!;
 
-            public ProxyCheckResult.IpResult Result { get; set; }
+            public ProxyCheckResult.IpResult Result { get; set; } = null!;
 
             public DateTimeOffset Time { get; set; }
 
@@ -31,7 +31,7 @@ namespace ProxyCheckUtil
             _maxCacheAge = maxCacheAge;
         }
 
-        public ProxyCheckResult.IpResult GetCacheRecord(IPAddress ip, ProxyCheckRequestOptions options)
+        public ProxyCheckResult.IpResult? GetCacheRecord(IPAddress ip, ProxyCheckRequestOptions options)
         {
             var results = GetCacheRecords(new[] {ip}, options);
 

--- a/ProxyCheckUtil.Tests/DeserializeTest.cs
+++ b/ProxyCheckUtil.Tests/DeserializeTest.cs
@@ -1,0 +1,114 @@
+﻿using System.Net;
+using NSubstitute;
+
+namespace ProxyCheckUtil.Tests;
+
+public class DeserializeTest
+{
+    [Fact]
+    public async Task TestSuccess()
+    {
+        const string json =
+            """
+            {
+                "status": "ok",
+                "104.16.255.200": {
+                    "asn": "AS13335",
+                    "range": "104.16.0.0/16",
+                    "provider": "CLOUDFLARENET - Cloudflare, Inc., US",
+                    "organisation": "Cloudflare, Inc.",
+                    "continent": "North America",
+                    "continentcode": "NA",
+                    "country": "Canada",
+                    "isocode": "CA",
+                    "region": "Ontario",
+                    "regioncode": "ON",
+                    "timezone": "America/Toronto",
+                    "city": "Toronto",
+                    "postcode": "M5A",
+                    "latitude": 43.6532,
+                    "longitude": -79.3832,
+                    "currency": {
+                        "code": "CAD",
+                        "name": "Dollar",
+                        "symbol": "CA$"
+                    },
+                    "devices": {
+                        "address": 0,
+                        "subnet": 0
+                    },
+                    "proxy": "no",
+                    "type": "Business"
+                }
+            }
+            """;
+
+        // Arrange
+        var handler = Substitute.For<HttpMessageHandler>();
+        handler
+            .SetupRequest(HttpMethod.Post, "https://proxycheck.io/v2/&vpn=0&asn=0&node=0&time=0&inf=1&port=0&seen=0&days=7&risk=0")
+            .ReturnsResponse(HttpStatusCode.OK, json);
+
+        using var client = new HttpClient(handler);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient().Returns(client);
+
+        var proxyCheck = new ProxyCheck(httpClientFactory)
+        {
+            UseTLS = true
+        };
+
+        // Act
+        var result = await proxyCheck.QueryAsync("104.16.255.200");
+
+        // Assert
+        Assert.Equal(StatusResult.OK, result.Status);
+        Assert.Single(result.Results);
+
+        var ipResult = result.Results.First().Value;
+        Assert.Equal("AS13335", ipResult.ASN);
+        Assert.Equal("CLOUDFLARENET - Cloudflare, Inc., US", ipResult.Provider);
+        Assert.Equal("Canada", ipResult.Country);
+        Assert.Equal(43.6532, ipResult.Latitude);
+        Assert.Equal(-79.3832, ipResult.Longitude);
+        Assert.Equal("Toronto", ipResult.City);
+        Assert.Equal("CA", ipResult.ISOCode);
+        Assert.False(ipResult.IsProxy);
+        Assert.Equal("Business", ipResult.ProxyType);
+    }
+
+    [Fact]
+    public async Task ExtensionsTest()
+    {
+        const string json =
+            """
+            {
+                "foo": "bar"
+            }
+            """;
+
+        // Arrange
+        var handler = Substitute.For<HttpMessageHandler>();
+        handler
+            .SetupRequest(HttpMethod.Post, "https://proxycheck.io/v2/&vpn=0&asn=0&node=0&time=0&inf=1&port=0&seen=0&days=7&risk=0")
+            .ReturnsResponse(HttpStatusCode.OK, json);
+
+        using var client = new HttpClient(handler);
+
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient().Returns(client);
+
+        var proxyCheck = new ProxyCheck(httpClientFactory)
+        {
+            UseTLS = true
+        };
+
+        // Act
+        var result = await proxyCheck.QueryAsync("104.16.255.200");
+
+        // Assert
+        Assert.Single(result.ExtensionData);
+        Assert.Equal("bar", result.ExtensionData["foo"].GetString());
+    }
+}

--- a/ProxyCheckUtil.Tests/NSubstituteExtensions.cs
+++ b/ProxyCheckUtil.Tests/NSubstituteExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using System.Reflection;
+using NSubstitute;
+using NSubstitute.Core;
+
+namespace ProxyCheckUtil.Tests;
+
+public static class NSubstituteExtensions
+{
+    public static HttpMessageHandler SetupRequest(this HttpMessageHandler handler, HttpMethod method, string requestUri)
+    {
+        handler
+            .GetType()
+            .GetMethod("SendAsync", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(handler, [
+                Arg.Is<HttpRequestMessage>(x =>
+                    x.Method == method &&
+                    x.RequestUri != null &&
+                    x.RequestUri.ToString() == requestUri),
+                Arg.Any<CancellationToken>()
+            ]);
+
+        return handler;
+    }
+
+    public static ConfiguredCall ReturnsResponse(this HttpMessageHandler handler, HttpStatusCode statusCode, string? jsonContent = null)
+    {
+        return ((object)handler).Returns(
+            Task.FromResult(new HttpResponseMessage()
+            {
+                StatusCode = statusCode,
+                Content = jsonContent != null ? new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json") : null
+            })
+        );
+    }
+
+    public static void ShouldHaveReceived(this HttpMessageHandler handler, HttpMethod requestMethod, string requestUri, int timesCalled = 1)
+    {
+        var calls = handler.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == "SendAsync")
+            .Select(call => call.GetOriginalArguments().First())
+            .Cast<HttpRequestMessage>()
+            .Where(request =>
+                request.Method == requestMethod &&
+                request.RequestUri != null &&
+                request.RequestUri.ToString() == requestUri
+            );
+
+        Assert.Equal(timesCalled, calls.Count());
+    }
+}

--- a/ProxyCheckUtil.Tests/ProxyCheckUtil.Tests.csproj
+++ b/ProxyCheckUtil.Tests/ProxyCheckUtil.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="xunit" Version="2.9.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ProxyCheck\ProxyCheckUtil.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR changes the JSON parsing to System.Text.Json instead of Newtonsoft.Json.

Also changed that the HttpClient is being managed by IHttpClientFactory (when used in DI).  
Currently we're creating a HttpClient every request. While the following post is from 2016 and maybe improved in .NET, it's still bad practice: https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/  
A singleton HttpClient is better but will fail if `proxycheck.io` changes their DNS.

Also, I enabled nullable so I'm sure that I didn't miss any null checks, and trimming for AOT cuz why not.

The project has now 0 warnings. 🔥